### PR TITLE
修复timestamp utctime单独使用或者在数组中类型不一致

### DIFF
--- a/src/TypeChecker.ts
+++ b/src/TypeChecker.ts
@@ -271,7 +271,7 @@ export class CTypeChecker
 				}
 				break;
 			case EType.date:
-				return CTypeChecker._FixDateFmt(value.v, this._type).toString();
+				return CTypeChecker._FixDateFmt(value.v, this._type);
 		}
 		return value.w;
 	}


### PR DESCRIPTION
timestamp utctime类型单独导出是字符串
数组类型却是整数数组